### PR TITLE
dmitigr_pgfe.cmake: fix missing file in dmitigr_pgfe_headers

### DIFF
--- a/cmake/dmitigr_pgfe.cmake
+++ b/cmake/dmitigr_pgfe.cmake
@@ -61,6 +61,7 @@ set(dmitigr_pgfe_headers
   statement.hpp
   statement_vector.hpp
   transaction_guard.hpp
+  tuple.hpp
   types_fwd.hpp
   )
 


### PR DESCRIPTION
"tuple.hpp" was missed in dmitigr_pgfe_headers leading to error when using installed version