### PR TITLE
account for errno being set to EINVAL on Apple clang

### DIFF
--- a/src/pgfe/completion.cpp
+++ b/src/pgfe/completion.cpp
@@ -57,12 +57,12 @@ DMITIGR_PGFE_INLINE Completion::Completion(const std::string_view tag)
       errno = 0;
       char* p{};
       const long number = std::strtol(word.c_str(), &p, 10);
-      if (const int err = errno)
-        throw Client_exception{"cannot parse command completion tag:"
-          " " + os::error_message(err)};
       if (p == word.c_str())
         // The word is not a number.
         break;
+      else if (errno != 0)
+        throw Client_exception{"cannot parse command completion tag:"
+          " " + os::error_message(errno)};
       else if (row_count_ < 0)
         row_count_ = number;
 


### PR DESCRIPTION
I was trying to set up a "hello world" usage of pgfe connection pools in my C++ application, when I encountered this error:

libc++abi: terminating due to uncaught exception of type dmitigr::pgfe::Client_exception: cannot parse command completion tag: Invalid argument

I went down the rabbit hole, and it looks like the following is occurring:
- `DISCARD ALL` is executed [here](https://github.com/dmitigr/pgfe/blob/0e1ac4c91fee886e17133727448540f6bf4e524e/src/pgfe/connection_pool.cpp#L112C5-L112C33)
- Postgres sends a completion tag of `DISCARD ALL`
- `std::strtol` attempts to parse `ALL`, and sets errno to `22` / `EINVAL`
- throws the Client_exception which crashes the program

I'm not sure whether setting EINVAL is standards-compliant behavior. [This link](https://en.cppreference.com/w/cpp/string/byte/strtol) only mentions ERANGE. [This link
](https://man7.org/linux/man-pages/man3/strtol.3.html) mentions EINVAL.

Whether or not it is standards-compliant, I believe we can change the code according to this PR.

I think my change has the same behavior for successful parsing and for ERANGE: if word were to be `9223372036854775808` (one more than `LONG_MAX`) then  `p != word.c_str()`. And now it supports EINVAL appropriately

```sh
/usr/bin/c++ --version
Apple clang version 16.0.0 (clang-1600.0.26.6)
Target: arm64-apple-darwin24.3.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

Apologies if I'm off the mark here. This is my first C++ project 🙂. I hope this is a useful contribution.